### PR TITLE
Fix: Prevent NaN values in Normalized Return Density (NRD) calculation

### DIFF
--- a/R/fCBDprofile_fuelmetrics.R
+++ b/R/fCBDprofile_fuelmetrics.R
@@ -83,6 +83,7 @@ fCBDprofile_fuelmetrics=function(datatype="Pixel",X,Y,Z,Zref,ReturnNumber,Eastin
   Ni=hist(Z,breaks=seq_layer,plot=F)$count
   N=cumsum(Ni)
   NRD=Ni/N
+  NRD[is.nan(NRD)] <- 0
   ## NRD estimation  ----
   # Ni +1 et N +2 pour les cas où Ni=0 ou NRD=1 => NRDc de l'equations 23 et 24 de Pimont et al 2018
   NRD[NRD==0]=(Ni[NRD==0]+1)/(N[NRD==0]+2)


### PR DESCRIPTION
This PR fixes a bug in the fCBDprofile_fuelmetrics function where a 0 / 0 division could occur during the Normalized Return Density (NRD) calculation, producing NaN values and breaking the workflow.